### PR TITLE
feat(yaml): add declarative YAML MVP parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["modules/parser", "modules/crond", "modules/uri", "modules/json"]
+members = ["modules/parser", "modules/crond", "modules/uri", "modules/json", "modules/yaml"]
 resolver = "2"

--- a/modules/yaml/Cargo.toml
+++ b/modules/yaml/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "oni-comb-yaml"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "MVP YAML parser built on oni-comb-parser"
+
+[dependencies]
+oni-comb-parser = { path = "../parser" }

--- a/modules/yaml/src/lib.rs
+++ b/modules/yaml/src/lib.rs
@@ -1,0 +1,7 @@
+//! MVP YAML parser built on oni-comb-parser.
+
+mod parser;
+mod value;
+
+pub use parser::{parse, parse_value, yaml, yaml_value};
+pub use value::YamlValue;

--- a/modules/yaml/src/parser.rs
+++ b/modules/yaml/src/parser.rs
@@ -18,7 +18,7 @@ where
 }
 
 fn classify_plain_scalar<'a>(text: &'a str) -> Result<YamlValue<'a>, ()> {
-  let trimmed = text.trim_end();
+  let trimmed = strip_trailing_comment(text).trim_end();
   if trimmed.is_empty() {
     return Err(());
   }
@@ -32,6 +32,17 @@ fn classify_plain_scalar<'a>(text: &'a str) -> Result<YamlValue<'a>, ()> {
       _ => YamlValue::String(Cow::Borrowed(trimmed)),
     },
   })
+}
+
+fn strip_trailing_comment(text: &str) -> &str {
+  let mut previous = None;
+  for (index, ch) in text.char_indices() {
+    if ch == '#' && previous.is_some_and(|prev: char| prev == ' ') {
+      return &text[..index];
+    }
+    previous = Some(ch);
+  }
+  text
 }
 
 fn line_start<'a>() -> impl Parser<StrInputStream<'a>, Output = (), Error = ParseError> {
@@ -112,7 +123,7 @@ fn double_quoted_scalar<'a>() -> BoxParser<'a, YamlValue<'a>> {
 
 fn plain_key<'a>() -> BoxParser<'a, YamlValue<'a>> {
   boxed(
-    take_till1(|c: char| matches!(c, ':' | '#' | '\n'))
+    take_till1(|c: char| matches!(c, ':' | '\n'))
       .map_res(classify_plain_scalar, "YAML mapping key")
       .context("YAML key"),
   )
@@ -124,7 +135,7 @@ fn not_flow_start<'a>() -> BoxParser<'a, ()> {
 
 fn block_plain_scalar<'a>() -> BoxParser<'a, YamlValue<'a>> {
   boxed(
-    take_till1(|c: char| matches!(c, '#' | '\n'))
+    take_till1(|c: char| matches!(c, '\n'))
       .map_res(classify_plain_scalar, "YAML plain scalar")
       .context("YAML plain scalar"),
   )
@@ -132,7 +143,7 @@ fn block_plain_scalar<'a>() -> BoxParser<'a, YamlValue<'a>> {
 
 fn flow_plain_scalar<'a>() -> BoxParser<'a, YamlValue<'a>> {
   boxed(
-    take_till1(|c: char| matches!(c, ',' | ']' | '}' | '#' | '\n'))
+    take_till1(|c: char| matches!(c, ',' | ']' | '}' | '\n'))
       .map_res(classify_plain_scalar, "YAML flow plain scalar")
       .context("YAML flow plain scalar"),
   )
@@ -146,7 +157,7 @@ fn flow_key<'a>() -> BoxParser<'a, YamlValue<'a>> {
   boxed(
     quoted_scalar()
       .or(
-        take_till1(|c: char| matches!(c, ':' | ',' | ']' | '}' | '#' | '\n'))
+        take_till1(|c: char| matches!(c, ':' | ',' | ']' | '}' | '\n'))
           .map_res(classify_plain_scalar, "YAML flow key"),
       )
       .context("YAML key"),
@@ -267,10 +278,7 @@ fn block_mapping_entry_at<'a>(indent: usize) -> BoxParser<'a, (YamlValue<'a>, Ya
       .zip_right(plain_key())
       .zip_left(spaces0().zip_right(char(':')))
       .flat_map(move |key| {
-        let nested = spaces0()
-          .zip_right(line_comment().optional())
-          .zip_left(char('\n').peek())
-          .zip_right(nested_block_value_at(indent).cut());
+        let nested = spaces0().zip_left(char('\n').peek()).zip_right(nested_block_value_at(indent).cut());
         let inline = spaces1().zip_right(block_inline_value()).zip_left(line_end_or_eof());
 
         boxed(

--- a/modules/yaml/src/parser.rs
+++ b/modules/yaml/src/parser.rs
@@ -119,7 +119,7 @@ fn plain_key<'a>() -> BoxParser<'a, YamlValue<'a>> {
 }
 
 fn not_flow_start<'a>() -> BoxParser<'a, ()> {
-  boxed(char('{').or(char('[')).not())
+  boxed(seq("- ").not().zip_right(char('{').or(char('[')).not()))
 }
 
 fn block_plain_scalar<'a>() -> BoxParser<'a, YamlValue<'a>> {

--- a/modules/yaml/src/parser.rs
+++ b/modules/yaml/src/parser.rs
@@ -1,0 +1,326 @@
+use std::borrow::Cow;
+use std::boxed::Box;
+
+use oni_comb_parser::error::{ExpectError, Expected, ParseError};
+use oni_comb_parser::input_stream::InputStream;
+use oni_comb_parser::parser::Parser;
+use oni_comb_parser::parser_ext::ParserExt;
+use oni_comb_parser::prelude::*;
+
+use crate::value::YamlValue;
+
+type BoxParser<'a, O> = Box<dyn Parser<StrInputStream<'a>, Output = O, Error = ParseError> + 'a>;
+
+fn boxed<'a, O, P>(parser: P) -> BoxParser<'a, O>
+where
+  P: Parser<StrInputStream<'a>, Output = O, Error = ParseError> + 'a, {
+  Box::new(parser)
+}
+
+fn classify_plain_scalar<'a>(text: &'a str) -> Result<YamlValue<'a>, ()> {
+  let trimmed = text.trim_end();
+  if trimmed.is_empty() {
+    return Err(());
+  }
+
+  Ok(match trimmed {
+    "null" => YamlValue::Null,
+    "true" => YamlValue::Bool(true),
+    "false" => YamlValue::Bool(false),
+    _ => match trimmed.parse::<i64>() {
+      Ok(value) if trimmed.chars().all(|c| c == '-' || c.is_ascii_digit()) => YamlValue::Integer(value),
+      _ => YamlValue::String(Cow::Borrowed(trimmed)),
+    },
+  })
+}
+
+fn line_start<'a>() -> impl Parser<StrInputStream<'a>, Output = (), Error = ParseError> {
+  guard(|input: &StrInputStream<'_>| input.offset() == input.line_start())
+}
+
+fn exact_indent<'a>(indent: usize) -> BoxParser<'a, ()> {
+  boxed(
+    line_start()
+      .zip_right(take_while0(|c: char| c == ' '))
+      .flat_map(move |spaces: &'a str| boxed(guard(move |_input: &StrInputStream<'_>| spaces.len() == indent)))
+      .discard()
+      .context("expected indentation"),
+  )
+}
+
+fn spaces0<'a>() -> impl Parser<StrInputStream<'a>, Output = &'a str, Error = ParseError> {
+  take_while0(|c: char| c == ' ')
+}
+
+fn spaces1<'a>() -> impl Parser<StrInputStream<'a>, Output = &'a str, Error = ParseError> {
+  take_while1(|c: char| c == ' ')
+}
+
+fn line_comment<'a>() -> impl Parser<StrInputStream<'a>, Output = (), Error = ParseError> {
+  char('#').zip_right(take_till0(|c: char| c == '\n')).discard()
+}
+
+fn blank_line<'a>() -> BoxParser<'a, ()> {
+  boxed(
+    spaces0()
+      .zip_right(line_comment().optional())
+      .zip_left(char('\n'))
+      .discard(),
+  )
+}
+
+fn line_end_or_eof<'a>() -> BoxParser<'a, ()> {
+  boxed(
+    spaces0()
+      .zip_right(line_comment().optional())
+      .zip_right(char('\n').discard().or(eof()))
+      .discard(),
+  )
+}
+
+fn document_end<'a>() -> BoxParser<'a, ()> {
+  boxed(
+    blank_line().many0().zip_right(
+      spaces0()
+        .flat_map(move |spaces: &'a str| {
+          let tail = line_comment().optional().zip_left(eof()).discard();
+          if spaces.is_empty() {
+            boxed(tail)
+          } else {
+            boxed(tail.context("expected indentation"))
+          }
+        })
+        .discard(),
+    ),
+  )
+}
+
+fn leading_blank_lines<'a>() -> BoxParser<'a, ()> {
+  boxed(blank_line().many0().discard())
+}
+
+fn single_quoted_scalar<'a>() -> BoxParser<'a, YamlValue<'a>> {
+  boxed(
+    between(char('\''), take_till0(|c: char| c == '\''), char('\''))
+      .map(|value: &'a str| YamlValue::String(Cow::Borrowed(value))),
+  )
+}
+
+fn double_quoted_scalar<'a>() -> BoxParser<'a, YamlValue<'a>> {
+  boxed(quoted_string().map(YamlValue::String))
+}
+
+fn plain_key<'a>() -> BoxParser<'a, YamlValue<'a>> {
+  boxed(
+    take_till1(|c: char| matches!(c, ':' | '#' | '\n'))
+      .map_res(classify_plain_scalar, "YAML mapping key")
+      .context("YAML key"),
+  )
+}
+
+fn not_flow_start<'a>() -> BoxParser<'a, ()> {
+  boxed(char('{').or(char('[')).not())
+}
+
+fn block_plain_scalar<'a>() -> BoxParser<'a, YamlValue<'a>> {
+  boxed(
+    take_till1(|c: char| matches!(c, '#' | '\n'))
+      .map_res(classify_plain_scalar, "YAML plain scalar")
+      .context("YAML plain scalar"),
+  )
+}
+
+fn flow_plain_scalar<'a>() -> BoxParser<'a, YamlValue<'a>> {
+  boxed(
+    take_till1(|c: char| matches!(c, ',' | ']' | '}' | '#' | '\n'))
+      .map_res(classify_plain_scalar, "YAML flow plain scalar")
+      .context("YAML flow plain scalar"),
+  )
+}
+
+fn quoted_scalar<'a>() -> BoxParser<'a, YamlValue<'a>> {
+  boxed(single_quoted_scalar().or(double_quoted_scalar()))
+}
+
+fn flow_key<'a>() -> BoxParser<'a, YamlValue<'a>> {
+  boxed(
+    quoted_scalar()
+      .or(
+        take_till1(|c: char| matches!(c, ':' | ',' | ']' | '}' | '#' | '\n'))
+          .map_res(classify_plain_scalar, "YAML flow key"),
+      )
+      .context("YAML key"),
+  )
+}
+
+fn flow_separator<'a>() -> BoxParser<'a, ()> {
+  boxed(spaces0().zip_right(char(',')).zip_right(spaces0()).discard())
+}
+
+fn flow_sequence_with<'a, P>(value: P) -> BoxParser<'a, YamlValue<'a>>
+where
+  P: Parser<StrInputStream<'a>, Output = YamlValue<'a>, Error = ParseError> + Clone + 'a, {
+  boxed(
+    char('[')
+      .zip_right(spaces0())
+      .zip_right(value.sep_by0(flow_separator()))
+      .zip_left(spaces0().zip_right(char(']').cut()))
+      .map(YamlValue::Sequence)
+      .context("YAML flow sequence"),
+  )
+}
+
+fn flow_mapping_entry_with<'a, P>(value: P) -> BoxParser<'a, (YamlValue<'a>, YamlValue<'a>)>
+where
+  P: Parser<StrInputStream<'a>, Output = YamlValue<'a>, Error = ParseError> + Clone + 'a, {
+  boxed(
+    flow_key()
+      .zip_left(spaces0().zip_right(char(':')).zip_right(spaces0()).cut())
+      .zip(value),
+  )
+}
+
+fn flow_mapping_with<'a, P>(value: P) -> BoxParser<'a, YamlValue<'a>>
+where
+  P: Parser<StrInputStream<'a>, Output = YamlValue<'a>, Error = ParseError> + Clone + 'a, {
+  boxed(
+    char('{')
+      .zip_right(spaces0())
+      .zip_right(flow_mapping_entry_with(value).sep_by0(flow_separator()))
+      .zip_left(spaces0().zip_right(char('}').cut()))
+      .map(YamlValue::Mapping)
+      .context("YAML flow mapping"),
+  )
+}
+
+fn flow_value<'a>() -> impl Parser<StrInputStream<'a>, Output = YamlValue<'a>, Error = ParseError> + Clone {
+  recursive(|value| {
+    flow_mapping_with(value.clone())
+      .or(flow_sequence_with(value))
+      .or(quoted_scalar())
+      .or(flow_plain_scalar())
+      .context("YAML flow value")
+  })
+}
+
+fn block_inline_value<'a>() -> BoxParser<'a, YamlValue<'a>> {
+  boxed(
+    flow_mapping_with(flow_value())
+      .or(flow_sequence_with(flow_value()))
+      .or(quoted_scalar())
+      .or(block_plain_scalar())
+      .context("YAML inline value"),
+  )
+}
+
+fn block_scalar_line_at<'a>(indent: usize) -> BoxParser<'a, YamlValue<'a>> {
+  boxed(
+    exact_indent(indent)
+      .zip_right(block_inline_value())
+      .zip_left(line_end_or_eof()),
+  )
+}
+
+fn block_sequence_item_at<'a>(indent: usize) -> BoxParser<'a, YamlValue<'a>> {
+  boxed(
+    exact_indent(indent)
+      .zip_right(seq("- "))
+      .zip_right(block_inline_value().cut())
+      .zip_left(line_end_or_eof())
+      .context("YAML block sequence item"),
+  )
+}
+
+fn block_sequence_at<'a>(indent: usize) -> BoxParser<'a, YamlValue<'a>> {
+  boxed(
+    block_sequence_item_at(indent)
+      .many1()
+      .map(YamlValue::Sequence)
+      .context("YAML block sequence"),
+  )
+}
+
+fn block_mapping_entry_at<'a>(indent: usize) -> BoxParser<'a, (YamlValue<'a>, YamlValue<'a>)> {
+  boxed(
+    exact_indent(indent)
+      .zip_right(not_flow_start())
+      .zip_right(plain_key())
+      .zip_left(spaces0().zip_right(char(':')))
+      .flat_map(move |key| {
+        let nested = spaces0()
+          .zip_right(line_comment().optional())
+          .zip_right(char('\n').zip_right(block_value_at(indent + 2).cut()));
+        let inline = spaces1().zip_right(block_inline_value()).zip_left(line_end_or_eof());
+
+        boxed(
+          nested
+            .or(inline)
+            .cut()
+            .map(move |value| (key.clone(), value))
+            .context("YAML block mapping entry"),
+        )
+      }),
+  )
+}
+
+fn block_mapping_at<'a>(indent: usize) -> BoxParser<'a, YamlValue<'a>> {
+  boxed(
+    block_mapping_entry_at(indent)
+      .many1()
+      .map(YamlValue::Mapping)
+      .context("YAML block mapping"),
+  )
+}
+
+fn block_value_at<'a>(indent: usize) -> BoxParser<'a, YamlValue<'a>> {
+  boxed(
+    block_mapping_at(indent)
+      .or(block_sequence_at(indent))
+      .or(block_scalar_line_at(indent))
+      .context("YAML value"),
+  )
+}
+
+fn top_inline_value<'a>() -> BoxParser<'a, YamlValue<'a>> {
+  boxed(
+    flow_mapping_with(flow_value())
+      .or(flow_sequence_with(flow_value()))
+      .or(quoted_scalar())
+      .or(block_plain_scalar())
+      .context("YAML value"),
+  )
+}
+
+/// YAML value parser (does not require EOF).
+pub fn yaml_value<'a>() -> impl Parser<StrInputStream<'a>, Output = YamlValue<'a>, Error = ParseError> {
+  leading_blank_lines().zip_right(block_mapping_at(0).or(block_sequence_at(0)).or(top_inline_value()))
+}
+
+/// Complete YAML parser (value + trailing comments/newlines + EOF).
+pub fn yaml<'a>() -> impl Parser<StrInputStream<'a>, Output = YamlValue<'a>, Error = ParseError> {
+  yaml_value().zip_left(document_end())
+}
+
+fn fail_to_error(error: oni_comb_parser::fail::Fail<ParseError>) -> ParseError {
+  match error {
+    oni_comb_parser::fail::Fail::Backtrack(err) | oni_comb_parser::fail::Fail::Cut(err) => err,
+    oni_comb_parser::fail::Fail::Incomplete => ParseError::from_expected(0, Expected::Description("incomplete input")),
+    oni_comb_parser::fail::Fail::ZeroProgress => ParseError::from_expected(0, Expected::Description("zero progress")),
+  }
+}
+
+/// Parse a YAML document, returning the parsed value or an error.
+pub fn parse(src: &str) -> Result<YamlValue<'_>, ParseError> {
+  let mut input = StrInputStream::new(src);
+  yaml()
+    .parse_next(&mut input)
+    .map_err(|error| fail_to_error(error).fill_location_from_src(src))
+}
+
+/// Parse a YAML value without requiring EOF.
+pub fn parse_value(src: &str) -> Result<YamlValue<'_>, ParseError> {
+  let mut input = StrInputStream::new(src);
+  yaml_value()
+    .parse_next(&mut input)
+    .map_err(|error| fail_to_error(error).fill_location_from_src(src))
+}

--- a/modules/yaml/src/parser.rs
+++ b/modules/yaml/src/parser.rs
@@ -157,8 +157,7 @@ fn flow_key<'a>() -> BoxParser<'a, YamlValue<'a>> {
   boxed(
     quoted_scalar()
       .or(
-        take_till1(|c: char| matches!(c, ':' | ',' | ']' | '}' | '\n'))
-          .map_res(classify_plain_scalar, "YAML flow key"),
+        take_till1(|c: char| matches!(c, ':' | ',' | ']' | '}' | '\n')).map_res(classify_plain_scalar, "YAML flow key"),
       )
       .context("YAML key"),
   )
@@ -278,7 +277,9 @@ fn block_mapping_entry_at<'a>(indent: usize) -> BoxParser<'a, (YamlValue<'a>, Ya
       .zip_right(plain_key())
       .zip_left(spaces0().zip_right(char(':')))
       .flat_map(move |key| {
-        let nested = spaces0().zip_left(char('\n').peek()).zip_right(nested_block_value_at(indent).cut());
+        let nested = spaces0()
+          .zip_left(char('\n').peek())
+          .zip_right(nested_block_value_at(indent).cut());
         let inline = spaces1().zip_right(block_inline_value()).zip_left(line_end_or_eof());
 
         boxed(

--- a/modules/yaml/src/parser.rs
+++ b/modules/yaml/src/parser.rs
@@ -203,14 +203,18 @@ fn flow_value<'a>() -> impl Parser<StrInputStream<'a>, Output = YamlValue<'a>, E
   })
 }
 
-fn block_inline_value<'a>() -> BoxParser<'a, YamlValue<'a>> {
+fn inline_value_with_context<'a>(context: &'static str) -> BoxParser<'a, YamlValue<'a>> {
   boxed(
     flow_mapping_with(flow_value())
       .or(flow_sequence_with(flow_value()))
       .or(quoted_scalar())
       .or(block_plain_scalar())
-      .context("YAML inline value"),
+      .context(context),
   )
+}
+
+fn block_inline_value<'a>() -> BoxParser<'a, YamlValue<'a>> {
+  inline_value_with_context("YAML inline value")
 }
 
 fn block_scalar_line_at<'a>(indent: usize) -> BoxParser<'a, YamlValue<'a>> {
@@ -240,6 +244,22 @@ fn block_sequence_at<'a>(indent: usize) -> BoxParser<'a, YamlValue<'a>> {
   )
 }
 
+fn nested_block_value_at<'a>(parent_indent: usize) -> BoxParser<'a, YamlValue<'a>> {
+  boxed(
+    char('\n')
+      .zip_right(take_while1(|c: char| c == ' ').peek())
+      .flat_map(move |spaces: &'a str| {
+        let child_indent = spaces.len();
+        boxed(
+          guard(move |_input: &StrInputStream<'_>| child_indent > parent_indent)
+            .context("expected deeper indentation")
+            .zip_right(block_value_at(child_indent)),
+        )
+      })
+      .context("YAML nested block value"),
+  )
+}
+
 fn block_mapping_entry_at<'a>(indent: usize) -> BoxParser<'a, (YamlValue<'a>, YamlValue<'a>)> {
   boxed(
     exact_indent(indent)
@@ -249,7 +269,8 @@ fn block_mapping_entry_at<'a>(indent: usize) -> BoxParser<'a, (YamlValue<'a>, Ya
       .flat_map(move |key| {
         let nested = spaces0()
           .zip_right(line_comment().optional())
-          .zip_right(char('\n').zip_right(block_value_at(indent + 2).cut()));
+          .zip_left(char('\n').peek())
+          .zip_right(nested_block_value_at(indent).cut());
         let inline = spaces1().zip_right(block_inline_value()).zip_left(line_end_or_eof());
 
         boxed(
@@ -282,13 +303,7 @@ fn block_value_at<'a>(indent: usize) -> BoxParser<'a, YamlValue<'a>> {
 }
 
 fn top_inline_value<'a>() -> BoxParser<'a, YamlValue<'a>> {
-  boxed(
-    flow_mapping_with(flow_value())
-      .or(flow_sequence_with(flow_value()))
-      .or(quoted_scalar())
-      .or(block_plain_scalar())
-      .context("YAML value"),
-  )
+  inline_value_with_context("YAML value")
 }
 
 /// YAML value parser (does not require EOF).

--- a/modules/yaml/src/value.rs
+++ b/modules/yaml/src/value.rs
@@ -1,0 +1,12 @@
+use std::borrow::Cow;
+
+/// MVP YAML value representation.
+#[derive(Debug, Clone, PartialEq)]
+pub enum YamlValue<'a> {
+  Null,
+  Bool(bool),
+  Integer(i64),
+  String(Cow<'a, str>),
+  Sequence(Vec<YamlValue<'a>>),
+  Mapping(Vec<(YamlValue<'a>, YamlValue<'a>)>),
+}

--- a/modules/yaml/tests/yaml_parse.rs
+++ b/modules/yaml/tests/yaml_parse.rs
@@ -65,6 +65,14 @@ fn parse_block_mapping_with_four_space_nested_block_sequence() {
 }
 
 #[test]
+fn parse_top_level_block_sequence_item_with_colon_as_sequence() {
+  assert_eq!(
+    parse("- name: milk\n- eggs\n").unwrap(),
+    sequence(vec![string("name: milk"), string("eggs")])
+  );
+}
+
+#[test]
 fn parse_flow_sequence_inside_block_mapping() {
   assert_eq!(
     parse("items: [one, two]\nnested:\n  key: value\n").unwrap(),

--- a/modules/yaml/tests/yaml_parse.rs
+++ b/modules/yaml/tests/yaml_parse.rs
@@ -106,7 +106,10 @@ fn parse_ignores_line_comment() {
 fn parse_preserves_hash_without_preceding_space_in_block_scalar() {
   assert_eq!(
     parse("color: #ff0000\nlabel: foo#bar").unwrap(),
-    mapping(vec![(string("color"), string("#ff0000")), (string("label"), string("foo#bar"))])
+    mapping(vec![
+      (string("color"), string("#ff0000")),
+      (string("label"), string("foo#bar"))
+    ])
   );
 }
 
@@ -122,7 +125,10 @@ fn parse_preserves_hash_without_preceding_space_in_keys() {
 fn parse_preserves_hash_without_preceding_space_in_flow_mapping() {
   assert_eq!(
     parse("{foo#bar: baz, color: #ff0000}").unwrap(),
-    mapping(vec![(string("foo#bar"), string("baz")), (string("color"), string("#ff0000"))])
+    mapping(vec![
+      (string("foo#bar"), string("baz")),
+      (string("color"), string("#ff0000"))
+    ])
   );
 }
 

--- a/modules/yaml/tests/yaml_parse.rs
+++ b/modules/yaml/tests/yaml_parse.rs
@@ -1,0 +1,134 @@
+use std::borrow::Cow;
+
+use oni_comb_parser::input_stream::InputStream;
+use oni_comb_parser::parser::Parser;
+use oni_comb_parser::prelude::StrInputStream;
+use oni_comb_yaml::{parse, parse_value, yaml_value, YamlValue};
+
+fn string(value: &'static str) -> YamlValue<'static> {
+  YamlValue::String(Cow::Borrowed(value))
+}
+
+fn mapping(entries: Vec<(YamlValue<'static>, YamlValue<'static>)>) -> YamlValue<'static> {
+  YamlValue::Mapping(entries)
+}
+
+fn sequence(values: Vec<YamlValue<'static>>) -> YamlValue<'static> {
+  YamlValue::Sequence(values)
+}
+
+#[test]
+fn parse_plain_scalar_mapping() {
+  assert_eq!(
+    parse("title: hello world").unwrap(),
+    mapping(vec![(string("title"), string("hello world"))])
+  );
+}
+
+#[test]
+fn parse_quoted_scalars() {
+  assert_eq!(
+    parse("single: 'hello'\ndouble: \"world\"").unwrap(),
+    mapping(vec![
+      (string("single"), string("hello")),
+      (string("double"), string("world"))
+    ])
+  );
+}
+
+#[test]
+fn parse_null_bool_and_integer() {
+  assert_eq!(
+    parse("a: null\nb: true\nc: 42").unwrap(),
+    mapping(vec![
+      (string("a"), YamlValue::Null),
+      (string("b"), YamlValue::Bool(true)),
+      (string("c"), YamlValue::Integer(42)),
+    ])
+  );
+}
+
+#[test]
+fn parse_block_mapping_with_nested_block_sequence() {
+  assert_eq!(
+    parse("items:\n  - milk\n  - eggs\n").unwrap(),
+    mapping(vec![(string("items"), sequence(vec![string("milk"), string("eggs")]))])
+  );
+}
+
+#[test]
+fn parse_flow_sequence_inside_block_mapping() {
+  assert_eq!(
+    parse("items: [one, two]\nnested:\n  key: value\n").unwrap(),
+    mapping(vec![
+      (string("items"), sequence(vec![string("one"), string("two")])),
+      (string("nested"), mapping(vec![(string("key"), string("value"))])),
+    ])
+  );
+}
+
+#[test]
+fn parse_top_level_flow_mapping() {
+  assert_eq!(
+    parse("{name: oni-comb, version: 2}").unwrap(),
+    mapping(vec![
+      (string("name"), string("oni-comb")),
+      (string("version"), YamlValue::Integer(2))
+    ])
+  );
+}
+
+#[test]
+fn parse_ignores_line_comment() {
+  assert_eq!(
+    parse("key: value # comment").unwrap(),
+    mapping(vec![(string("key"), string("value"))])
+  );
+}
+
+#[test]
+fn parse_ignores_comment_after_closed_flow_value() {
+  assert_eq!(
+    parse("items: [one, two] # comment").unwrap(),
+    mapping(vec![(string("items"), sequence(vec![string("one"), string("two")]))])
+  );
+}
+
+#[test]
+fn parse_rejects_trailing_non_comment_text() {
+  assert!(parse("[one, two], trailing").is_err());
+}
+
+#[test]
+fn parse_value_prefix_parses_closed_flow_collection() {
+  assert_eq!(
+    parse_value("[one, two], trailing").unwrap(),
+    sequence(vec![string("one"), string("two")])
+  );
+}
+
+#[test]
+fn yaml_value_parser_leaves_trailing_input() {
+  let mut input = StrInputStream::new("[one, two], trailing");
+  let parsed = yaml_value().parse_next(&mut input).unwrap();
+
+  assert_eq!(parsed, sequence(vec![string("one"), string("two")]));
+  assert_eq!(input.remaining(), ", trailing");
+}
+
+#[test]
+fn indentation_mismatch_reports_line_and_column() {
+  let err = parse("root:\n  child: ok\n next: wrong\n").unwrap_err();
+  assert_eq!(err.line, 3);
+  assert_eq!(err.column, 2);
+  assert!(!err.expected.is_empty());
+  assert!(err.context.iter().any(|ctx| ctx.contains("indentation")));
+}
+
+#[test]
+fn unterminated_flow_collection_reports_context() {
+  let err = parse("items: [one, two").unwrap_err();
+  assert!(err.position > 0);
+  assert!(err.expected.contains(&oni_comb_parser::error::Expected::Char(']')));
+  assert!(!err.context.is_empty());
+}

--- a/modules/yaml/tests/yaml_parse.rs
+++ b/modules/yaml/tests/yaml_parse.rs
@@ -57,6 +57,14 @@ fn parse_block_mapping_with_nested_block_sequence() {
 }
 
 #[test]
+fn parse_block_mapping_with_four_space_nested_block_sequence() {
+  assert_eq!(
+    parse("items:\n    - milk\n    - eggs\n").unwrap(),
+    mapping(vec![(string("items"), sequence(vec![string("milk"), string("eggs")]))])
+  );
+}
+
+#[test]
 fn parse_flow_sequence_inside_block_mapping() {
   assert_eq!(
     parse("items: [one, two]\nnested:\n  key: value\n").unwrap(),

--- a/modules/yaml/tests/yaml_parse.rs
+++ b/modules/yaml/tests/yaml_parse.rs
@@ -103,6 +103,30 @@ fn parse_ignores_line_comment() {
 }
 
 #[test]
+fn parse_preserves_hash_without_preceding_space_in_block_scalar() {
+  assert_eq!(
+    parse("color: #ff0000\nlabel: foo#bar").unwrap(),
+    mapping(vec![(string("color"), string("#ff0000")), (string("label"), string("foo#bar"))])
+  );
+}
+
+#[test]
+fn parse_preserves_hash_without_preceding_space_in_keys() {
+  assert_eq!(
+    parse("foo#bar: baz").unwrap(),
+    mapping(vec![(string("foo#bar"), string("baz"))])
+  );
+}
+
+#[test]
+fn parse_preserves_hash_without_preceding_space_in_flow_mapping() {
+  assert_eq!(
+    parse("{foo#bar: baz, color: #ff0000}").unwrap(),
+    mapping(vec![(string("foo#bar"), string("baz")), (string("color"), string("#ff0000"))])
+  );
+}
+
+#[test]
 fn parse_ignores_comment_after_closed_flow_value() {
   assert_eq!(
     parse("items: [one, two] # comment").unwrap(),

--- a/openspec/changes/yaml-parser-mvp/.openspec.yaml
+++ b/openspec/changes/yaml-parser-mvp/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-20

--- a/openspec/changes/yaml-parser-mvp/design.md
+++ b/openspec/changes/yaml-parser-mvp/design.md
@@ -1,0 +1,102 @@
+## Context
+
+`yaml-ready-parser` により、parser core は layout-sensitive grammar を支える公開契約をすでに備えている。特に `modules/parser/tests/yaml_ready_acceptance.rs` では、行頭判定、期待インデント、flow/block 文脈、simple-key gating、plain scalar boundary を、YAML 専用 API を parser core に追加せずに downstream-owned wrapper / helper で表現できることを確認済みである。
+
+一方で、現時点の `yaml-parser` capability は「YAML 実装は別 change で提案する」という gate しか持っておらず、実際の downstream crate、AST、public API、テスト方針はまだ存在しない。この change では readiness の実証を本物の downstream crate に進めるが、対象は full YAML ではなく MVP subset に限定する。
+
+## Goals / Non-Goals
+
+**Goals:**
+- `modules/yaml` crate を追加し、`oni-comb-yaml` として最小の downstream YAML parser を提供する
+- block mapping / block sequence / flow mapping / flow sequence を single-document grammar として parse できるようにする
+- plain / single-quoted / double-quoted string、`null`、`bool`、10 進 integer、comment をサポートする
+- parser 全体を関数型・宣言的・public combinator chain のみで記述する
+- parser core へ YAML 専用 API を追加せずに実装し、表現不能なら不足をフィードバックできるようにする
+- line / column / context を含む `ParseError` ベースの診断を downstream parser でも保つ
+
+**Non-Goals:**
+- YAML 1.2 全面対応
+- block scalar (`|`, `>`)、chomping、folding の実装
+- anchor / alias / merge key / tag / multi-document の実装
+- advanced numeric schema（16 進、8 進、指数、`.inf`、`.nan` など）の完全対応
+- parser core へ新しい YAML 専用 primitive / combinator / layout API を追加すること
+- custom `Parser` 実装、`InputStream` wrapper、`parse_next` / `checkpoint/reset` / `next_token` 直呼び、戻り値破棄による命令型制御で不足を埋めること
+
+## Decisions
+
+### D1. `modules/yaml` は `modules/json` と同様の薄い crate 構成にする
+
+`modules/yaml` は `parser.rs`、`value.rs`、`lib.rs` を中心とした薄い downstream crate とする。public API は `yaml()` / `yaml_value()` と `parse()` / `parse_value()` 相当の 2 層を持たせる。
+
+- Why: 既存 downstream crate の構成に揃えると、公開面とテスト方針が一貫する
+- Alternative considered: 初期から細かいモジュールへ分割する
+- Why not: MVP 段階ではファイル分割より、公開契約と grammar の成立性の確認を優先したい
+
+### D2. YAML 文脈も declarative な combinator 合成だけで表現を試みる
+
+indentation、flow/block、simple-key のような YAML 文脈も、まずは existing public combinator と parser 出力の合成だけで表現を試みる。`StrInputStream` を包む wrapper や custom `Parser` 実装で stateful adaptation を隠蔽することは、この change では許容しない。
+
+- Why: この change の価値は「downstream 実装まで declarative に書けるか」を検証することにあり、imperative wrapper に逃げると不足の有無が見えなくなる
+- Alternative considered: `yaml_ready_acceptance` と同様に wrapper / helper parser を production 実装へ持ち込む
+- Why not: parser core の readiness を downstream 実装で再検証する目的がぼやける
+
+### D3. helper も pure helper function に限定し、命令型 escape hatch を禁止する
+
+top-level だけでなく内部抽象も public combinator chain の組み合わせで構成する。許容する helper は「parser を返す関数」までとし、custom `Parser` 実装、`parse_next` / checkpoint / reset / token stepping の直接利用、戻り値破棄による input 消費は行わない。
+
+- Why: helper の内部だけ命令型にすると、実質的に parser combinator を使わない実装でも通ってしまう
+- Alternative considered: top-level だけ declarative に見せて、helper の中で imperative に処理する
+- Why not: 今回まさにその方向が方針違反だったため
+
+### D4. AST は最小 enum とし、mapping は順序保持を優先する
+
+MVP の AST は `Null`、`Bool`、`Integer`、`String`、`Sequence`、`Mapping` を持つ最小 enum とする。`Mapping` は `Vec<(YamlValue<'a>, YamlValue<'a>)>` か同等の順序保持表現を使い、重複キーの解釈は MVP では固定しない。ただし grammar として受理する key は supported scalar subset に限定し、explicit key (`? key`) や collection-valued key はこの change では扱わない。
+
+- Why: YAML では key order や duplicate key policy が後で論点になりやすく、`BTreeMap` へ早期固定すると表現力を狭める
+- Alternative considered: `BTreeMap` を使って JSON と同型にする
+- Why not: duplicate key の扱いを勝手に消してしまい、後続 change の余地を減らす
+
+### D5. scalar subset は basic schema に限定する
+
+MVP scalar は plain / single-quoted / double-quoted string、`null`、`true` / `false`、10 進 integer に限定する。plain scalar は block と flow で停止条件を変える。comment は quoted scalar の内部では解釈せず、quoted scalar 外では value boundary の後に現れる `#` から行末までを line comment として無視する。
+
+- Why: YAML らしい文脈依存を保ちつつ、block scalar や advanced numeric schema まで広げないことで MVP を保てる
+- Alternative considered: 既存 `yaml-parser` spec にあった full scalar set を最初から実装する
+- Why not: layout-sensitive parser の成立検証よりも仕様消化の比重が大きくなりすぎる
+
+### D6. single document + full-consume parse を MVP の public contract にする
+
+`parse()` は 1 つの top-level YAML value を parse し、入力末尾まで消費する。`parse_value()` は value 単体 parser として EOF を要求せず、closed flow collection や quoted scalar のように終端が明確な値を prefix parse できる契約とする。document start / end marker や multi-document はこの change では扱わない。
+
+- Why: JSON crate と同じ API 形に揃えつつ、multi-document の複雑さを後続 change に送れる
+- Alternative considered: 最初から `Vec<Document>` を返す
+- Why not: top-level contract と AST が一気に重くなり、MVP を超える
+
+### D7. 表現不能なら実装を止めて不足を報告する
+
+ある grammar slice が public combinator chain だけでは表現不能だと判明した場合、その時点で実装を止めて不足理由をフィードバックする。報告では「MVP scope が広すぎる」のか、「parser core の generic capability が足りない」のか、「spec が曖昧なのか」を切り分ける。
+
+- Why: imperative fallback で埋めると、本当に不足しているものが見えなくなる
+- Alternative considered: 一時的な命令型コードで unblock して先に進む
+- Why not: feedback loop を失い、この change の検証価値が下がる
+
+## Risks / Trade-offs
+
+- [Risk] plain scalar の停止条件が曖昧だと flow/block の境界で誤受理しやすい → Mitigation: `yaml_ready_acceptance` の flow plain scalar litmus を直接参照し、flow と block の停止条件を acceptance test で固定する
+- [Risk] declarative-only 制約の下では一部 grammar が書けない可能性がある → Mitigation: その場合は implementation を停止し、不足する generic capability か scope 問題として artifacts にフィードバックする
+- [Risk] duplicate key policy を未決定のまま進めると後で互換性論点になる → Mitigation: MVP では mapping representation を順序保持にして policy を固定しない
+- [Risk] block scalar を除外すると「YAML らしさが足りない」と見える → Mitigation: proposal と spec で block scalar を明示的に non-goal とし、後続 change に切り出す
+
+## Migration Plan
+
+1. `modules/yaml` crate を workspace に追加する
+2. MVP AST と public parse API を追加する
+3. 各 grammar slice を public combinator chain だけで表現できるか小さく検証する
+4. block / flow collection と scalar subset を declarative に実装する
+5. parser / AST / error / comment handling の acceptance tests を追加する
+6. 表現不能な箇所が見つかった場合は、scope / capability / spec のどこに不足があるかを artifacts へ反映する
+7. full YAML scope へ拡張したくなった場合は、block scalar や anchors などを別 change として提案する
+
+## Open Questions
+
+- single-quoted / double-quoted string でどこまで escape を許すか

--- a/openspec/changes/yaml-parser-mvp/proposal.md
+++ b/openspec/changes/yaml-parser-mvp/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+`yaml-ready-parser` で parser core が layout-sensitive grammar を支えられることは実証できたが、まだ実際の downstream YAML parser crate は存在しない。次はその readiness を机上ではなく実コードで検証するために、YAML 全体ではなく最小の MVP subset を持つ parser を追加し、既存 public contract だけで成立することを確認する必要がある。
+
+## What Changes
+
+- `modules/yaml` crate を追加し、`oni-comb-yaml` として最小の downstream YAML parser を提供する
+- single document を対象に、block mapping / block sequence / flow mapping / flow sequence を parse できる MVP grammar を追加する
+- scalar は plain / single-quoted / double-quoted string、`null`、`bool`、10 進 integer に限定し、comment を無視できるようにする
+- mapping key は MVP では supported scalar subset に限定し、explicit key (`? key`) や collection-valued key は対象外とする
+- 実装は関数型・宣言的・public combinator chain のみで記述し、custom `Parser` 実装、`InputStream` wrapper、`parse_next` / `checkpoint/reset` / `next_token` 直呼び、戻り値破棄による命令型制御を用いない
+- 既存 public contract だけでは declarative に表現できない grammar が見つかった場合は、無理に実装せず不足する generic capability または過大な scope をフィードバックする
+- line / column / context を含む parse error を downstream YAML parser でも利用できることを確認する
+- block scalar (`|`, `>`)、anchor / alias、tag、multi-document、merge key、advanced numeric schema は MVP の対象外とする
+
+## Capabilities
+
+### New Capabilities
+
+<!-- None -->
+
+### Modified Capabilities
+
+- `yaml-parser`: placeholder だった downstream YAML capability を、MVP subset の具体的な parser / AST / error 契約へ更新する
+
+## Impact
+
+- `modules/yaml`: 新規 crate、parser 実装、AST、tests の追加対象
+- `Cargo.toml`: workspace member の追加が必要
+- `openspec/specs/yaml-parser/spec.md`: MVP subset の requirement へ更新する
+- `modules/parser/tests/yaml_ready_acceptance.rs`: parser core の成立性を示す参照資料として扱うが、この change では wrapper / imperative helper を production 実装へ持ち込まない
+- public API: `oni-comb-yaml` の `parse` / `parse_value` 相当 API と YAML AST の公開が必要
+- 表現不能ケース: parser core の generic capability 不足か、MVP scope の切り方の問題かを切り分けてフィードバックする必要がある

--- a/openspec/changes/yaml-parser-mvp/specs/yaml-parser/spec.md
+++ b/openspec/changes/yaml-parser-mvp/specs/yaml-parser/spec.md
@@ -1,0 +1,104 @@
+## MODIFIED Requirements
+
+### Requirement: YAML parser change stays downstream-owned until proposed separately
+The YAML parser capability SHALL be implemented as a dedicated downstream change and downstream crate, rather than by extending the parser core with YAML-specific APIs. The accepted MVP for this change MUST live in `modules/yaml` and provide a single-document YAML subset parser.
+
+#### Scenario: yaml parser exists as its own downstream crate
+- **WHEN** the `yaml-parser-mvp` change is implemented
+- **THEN** the workspace contains a `modules/yaml` crate
+- **AND** YAML-specific parsing logic and AST types live there instead of `modules/parser`
+
+#### Scenario: parser core remains YAML-agnostic
+- **WHEN** the MVP YAML parser is added
+- **THEN** `modules/parser` does not gain YAML-specific layout primitives or YAML-specific public state types
+
+### Requirement: YAML-specific behavior must compose from parser public contracts first
+The downstream YAML parser SHALL express indentation-sensitive, flow/block, and simple-key behavior by composing existing parser public contracts with declarative combinator chains only. It MUST NOT rely on custom `Parser` implementations, `InputStream` wrappers, `parse_next` / `checkpoint` / `reset` / token-stepping direct calls, discarded parser results, `fn_parser`, or ad hoc parser-core API additions as its primary implementation strategy.
+
+#### Scenario: internal helper stays declarative
+- **WHEN** the YAML parser's top-level grammar is reviewed
+- **THEN** block and flow productions are expressed as combinator pipelines
+- **AND** helper abstractions, if any, are functions returning composed parsers rather than imperative parser objects
+
+#### Scenario: declarative expression fails and implementation pauses
+- **WHEN** a required YAML grammar slice cannot be expressed using public combinator chains alone
+- **THEN** implementation stops for that slice
+- **AND** the team records whether the blocker is MVP scope, parser-core generic capability, or spec ambiguity instead of introducing imperative fallback code
+
+## ADDED Requirements
+
+### Requirement: YAML parser MVP parses single-document block and flow collections
+The MVP YAML parser SHALL parse one top-level YAML document containing block mappings, block sequences, flow mappings, and flow sequences, including nesting between block and flow forms. Mapping keys accepted by this MVP MUST be limited to the supported scalar subset. Explicit key syntax (`? key`) and collection-valued keys are out of scope for this change.
+
+#### Scenario: block mapping with nested block sequence
+- **WHEN** the parser reads:
+  ```
+  items:
+    - milk
+    - eggs
+  ```
+- **THEN** it returns a mapping whose `items` value is a two-element sequence
+
+#### Scenario: flow sequence inside block mapping
+- **WHEN** the parser reads:
+  ```
+  items: [one, two]
+  nested:
+    key: value
+  ```
+- **THEN** it returns a mapping that contains both a flow sequence value and a nested block mapping value
+
+#### Scenario: flow mapping at top level
+- **WHEN** the parser reads `{name: oni-comb, version: 2}`
+- **THEN** it returns a mapping with two entries
+
+### Requirement: YAML parser MVP parses the basic scalar subset and ignores comments
+The MVP YAML parser SHALL support plain scalars, single-quoted scalars, double-quoted scalars, `null`, `true` / `false`, and decimal integers. It MUST ignore line comments introduced by `#` after a value boundary and outside quoted scalars in both block and flow forms.
+
+#### Scenario: plain scalar
+- **WHEN** the parser reads `title: hello world`
+- **THEN** it returns a mapping whose value is the plain string `hello world`
+
+#### Scenario: quoted scalars
+- **WHEN** the parser reads `single: 'hello'\ndouble: "world"`
+- **THEN** it returns string values for both quoted scalars
+
+#### Scenario: null bool and integer
+- **WHEN** the parser reads `a: null\nb: true\nc: 42`
+- **THEN** it returns `Null`, `Bool(true)`, and `Integer(42)` values
+
+#### Scenario: line comment is ignored
+- **WHEN** the parser reads `key: value # comment`
+- **THEN** it returns the same mapping result as `key: value`
+
+#### Scenario: flow comment is ignored after a closed value
+- **WHEN** the parser reads `items: [one, two] # comment`
+- **THEN** it returns the same mapping result as `items: [one, two]`
+
+### Requirement: YAML parser MVP exposes a minimal public AST and parse API
+The MVP YAML parser SHALL expose a minimal public AST with variants for null, bool, integer, string, sequence, and mapping, plus parser entry points equivalent to `parse`, `parse_value`, `yaml`, and `yaml_value`.
+
+#### Scenario: parse consumes the whole document
+- **WHEN** the caller uses the full parse entry point on `key: value`
+- **THEN** it returns a mapping value
+- **AND** trailing non-comment text causes an error
+
+#### Scenario: parse_value does not require EOF
+- **WHEN** the caller uses the value-only parse entry point on `[one, two], trailing`
+- **THEN** it returns the flow sequence value without requiring the trailing `, trailing` input to be consumed
+
+### Requirement: YAML parser MVP returns location-aware parse errors
+The MVP YAML parser SHALL return parse errors that preserve line, column, expected token, and parser context information supplied by the parser core position/error model.
+
+#### Scenario: indentation mismatch reports location
+- **WHEN** the parser reads:
+  ```
+  root:
+    child: ok
+   next: wrong
+  ```
+- **THEN** it returns an error near line 3 with indentation-related expectation information
+
+#### Scenario: unterminated flow collection reports context
+- **WHEN** the parser reads `items: [one, two`
+- **THEN** it returns an error with location and expected closing-token context

--- a/openspec/changes/yaml-parser-mvp/tasks.md
+++ b/openspec/changes/yaml-parser-mvp/tasks.md
@@ -1,0 +1,30 @@
+## 1. Workspace and Crate Setup
+
+- [x] 1.1 workspace に `modules/yaml` を追加し、`oni-comb-yaml` crate の `Cargo.toml` と `lib.rs` を作成する
+- [x] 1.2 `modules/json` と同様の公開面に合わせて `parser.rs`、`value.rs`、public export を整える
+
+## 2. Declarative Feasibility
+
+- [x] 2.1 block mapping / block sequence / flow mapping / flow sequence / scalar subset の各 grammar slice を、public combinator chain のみで表現できるか小さく検証する
+- [x] 2.2 custom `Parser` 実装、`InputStream` wrapper、`parse_next` / `checkpoint/reset` / token stepping 直呼び、戻り値破棄による入力制御を使わない実装方針を保つ
+- [x] 2.3 declarative に表現できない requirement が見つかった場合は、実装を止めて不足理由を OpenSpec へフィードバックする
+
+## 3. AST and Public API
+
+- [x] 3.1 `Null`、`Bool`、`Integer`、`String`、`Sequence`、`Mapping` を持つ MVP YAML AST を定義する
+- [x] 3.2 `yaml()` / `yaml_value()` と `parse()` / `parse_value()` 相当の public API を実装する
+- [x] 3.3 `parse()` が入力全体を消費し、`parse_value()` が value 単体 parser として使える契約を実装する
+
+## 4. Declarative Grammar Implementation
+
+- [x] 4.1 plain / single-quoted / double-quoted string、`null`、`bool`、10 進 integer、block / flow の line comment handling を実装する
+- [x] 4.2 block mapping / block sequence を実装し、indentation に基づくネストと scalar-only mapping key 制約を扱えるようにする
+- [x] 4.3 flow mapping / flow sequence を実装し、block grammar との相互ネストを扱えるようにする
+
+## 5. Validation and Error Reporting
+
+- [x] 5.1 scalar / collection / nesting / block-flow comment の受け入れテストを追加する
+- [x] 5.2 trailing text、unterminated flow collection、indentation mismatch の失敗ケースを追加する
+- [x] 5.3 `parse_value()` が closed flow collection のような終端明確な値を prefix parse できることを検証する
+- [x] 5.4 downstream YAML parser が line / column / expected / context を含む parse error を返すことを検証する
+- [x] 5.5 実装が parser core への YAML 専用 API 追加なし、かつ命令型 fallback なしで成立したことを docs と OpenSpec の観点で再確認する


### PR DESCRIPTION
## Summary
- add a new `oni-comb-yaml` crate with a declarative YAML MVP parser for block/flow mappings and sequences plus the basic scalar subset
- keep the implementation within public combinator chains only, without custom `Parser` implementations, input wrappers, or imperative fallback control
- add `yaml-parser-mvp` OpenSpec artifacts that lock the MVP scope and the declarative-only implementation constraints

## Test plan
- [x] `cargo test -p oni-comb-yaml`
- [x] `cargo test`
- [x] `openspec validate "yaml-parser-mvp" --type change --json --no-interactive`


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new YAML parsing crate with non-trivial indentation/flow parsing and error handling; while isolated from existing crates, parsing edge cases could surface as bugs in downstream consumers.
> 
> **Overview**
> Introduces a new workspace member, `oni-comb-yaml`, providing an MVP YAML subset parser and minimal `YamlValue` AST, with public entry points `parse`/`parse_value` and `yaml`/`yaml_value`.
> 
> The parser supports block/flow mappings and sequences, basic scalars (`null`/bool/int/quoted/plain strings), indentation-based nesting, and comment handling, and adds a comprehensive test suite plus OpenSpec change docs/spec updates to lock the MVP scope and declarative-only constraints.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81689b744c6bcda5cf8790b1d02cdcbe3712d776. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->